### PR TITLE
Set a better title of the list link

### DIFF
--- a/src/components/RetroAppBar.js
+++ b/src/components/RetroAppBar.js
@@ -35,7 +35,7 @@ const RetroAppBar = props => {
     if (teamLink) {
       return (
         <Button color="contrast" component={Link} to={`/team/${teamLink}/list`}>
-          {teamLink}
+          {`List ${teamLink} items`}
         </Button>
       );
     }


### PR DESCRIPTION
The current link to the list of retro items just states the team name. I think a more descriptive title should be used.